### PR TITLE
Added atls.lib to PublicAdditionalLibraries.

### DIFF
--- a/Source/TextToSpeech.Build.cs
+++ b/Source/TextToSpeech.Build.cs
@@ -56,6 +56,8 @@ namespace UnrealBuildTool.Rules
 			PublicSystemLibraryPaths.Add(LibraryPath);
 			
 			PublicAdditionalLibraries.Add(Path.Combine(LibraryPath, "FMRTTSLib.lib"));
+			PublicAdditionalLibraries.Add(Path.Combine(LibraryPath, "atls.lib"));
+
 			PrivateIncludePaths.Add(Path.Combine(FMRTTSLibFolder, "include"));
 
 			PublicDefinitions.Add("WITH_FMRTTSLIB=1");


### PR DESCRIPTION
Added a single line of code to the .Build.cs, following @mbpictures words in the #2.

Before doing it, I had the same error as described in #5 interrupting the packaging. After doing it, my project packages successfully. (Thus, #2 and #5 are most likely the same issue.)